### PR TITLE
Merge from trunkmaster/master

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-04-20  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/x11/XGServerWindow.m (standardcursor::): Getting of
+	XC_fleur as GSCloseHandCursor was removed because it loads in
+	NSCursor as image.
+
 2019-04-18  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (standardcursor::): revert resizing

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4177,9 +4177,6 @@ xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,
     case GSIBeamCursor:
       cursor = XCreateFontCursor(dpy, XC_xterm);
       break;
-    case GSClosedHandCursor:
-      cursor = XCreateFontCursor(dpy, XC_fleur);
-      break;
     case GSOpenHandCursor:
       cursor = XCreateFontCursor(dpy, XC_hand1);
       break;


### PR DESCRIPTION
* Source/x11/XGServerWindow.m (standardcursor::): Getting of XC_fleur as GSCloseHandCursor was removed because it loads in
NSCursor as image.